### PR TITLE
Fix withdaw to withdraw and createWithdrawCmg->Cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Available Commands:
   completion                      Generate the autocompletion script for the specified shell
   create-phase1-staking-tx        create phase1 staking tx
   create-phase1-unbonding-request create phase1 unbonding tx
-  create-phase1-withdaw-request   create phase1 withdraw tx
+  create-phase1-withdraw-request   create phase1 withdraw tx
   create-timestamp-transaction    Creates a timestamp btc transaction by hashing the file input.
   dump-cfg                        dumps default confiiguration file
   help                            Help about any command

--- a/cmd/createWithdrawTxCmd.go
+++ b/cmd/createWithdrawTxCmd.go
@@ -66,7 +66,7 @@ type spendStakeTxInfo struct {
 }
 
 var createWithdrawCmd = &cobra.Command{
-	Use:   "create-phase1-withdaw-request",
+	Use:   "create-phase1-withdraw-request",
 	Short: "create phase1 withdraw tx ",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		btcParams, err := getBtcNetworkParams(mustGetStringFlag(cmd, FlagNetwork))

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -145,7 +145,7 @@ The following set of commands are used to create phase-1 compatible transactions
 with the goal to ease up testing of the phase-1 system:
 - `create-phase1-staking-tx`
 - `create-phase1-unbonding-request`
-- `create-phase1-withdaw-request`
+- `create-phase1-withdraw-request`
 
 Disclaimer: Those commands should only be used for testing purposes and should not be
 used with real BTC.


### PR DESCRIPTION
I noticed that the subcommand has a typo `withdaw` instead of `withdraw` as well as a filename createWithdrawCmg.go instead of createWithdrawCmd.go, this fixes these issues