### PR TITLE
CI: Enable Dockerfile and image scanning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,11 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.6.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.10.2
     secrets: inherit
     with:
      publish: true
+     docker_scan: true
+    permissions:
+      security-events: write
+      packages: read

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# LND < 0.17.0 issue, not fixing
+CVE-2024-27304
+GHSA-7jwh-3vrq-q3m8
+CVE-2024-27289
+CVE-2024-38359

--- a/go.mod
+++ b/go.mod
@@ -258,7 +258,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/rs/cors v1.8.3 // indirect
+	github.com/rs/cors v1.11.0 // indirect
 	github.com/rs/zerolog v1.32.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1186,6 +1186,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
 github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
+github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=


### PR DESCRIPTION
Some remaining CVE that may need analyzed:
<table>
    <tr>
        <th>Package</th>
        <th>ID</th>
        <th>Severity</th>
        <th>Installed Version</th>
        <th>Fixed Version</th>
    </tr>
    <tr>
        <td><code>cosmossdk.io/math</code></td>
        <td>GHSA-7225-m954-23v7</td>
        <td>HIGH</td>
        <td>v1.3.0</td>
        <td>1.4.0</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-p7mv-53f2-4cwj</td>
        <td>HIGH</td>
        <td>v0.38.7</td>
        <td>0.38.15</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-g5xx-c4hv-9ccc</td>
        <td>MEDIUM</td>
        <td>v0.38.7</td>
        <td>0.37.11, 0.38.12</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-hg58-rf2h-6rr7</td>
        <td>MEDIUM</td>
        <td>v0.38.7</td>
        <td>0.37.7, 0.38.8</td>
    </tr>
</table>